### PR TITLE
Fixing error on packages.pp

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -46,8 +46,8 @@ class fluentd::packages {
                 ensure => present,
             }~>
             exec {'add user td-agent to group adm':
-                unless  => 'grep -q "adm\S*td-agent" /etc/group',
-                command => 'usermod -aG adm td-agent',
+                unless  => '/bin/grep -q "adm\S*td-agent" /etc/group',
+                command => '/usr/sbin/usermod -aG adm td-agent',
             }
         }
         default: {


### PR DESCRIPTION
Hello,

I tried to use the module but got this error :
Error: Failed to apply catalog: Parameter unless failed on Exec[add user td-agent to group adm]: 'grep -q "adm\S_td-agent" /etc/group' is not qualified and no path was specified. Please qualify the command or specify a path. at /etc/puppet/modules/fluentd/manifests/packages.pp:51
Wrapped exception:
'grep -q "adm\S_td-agent" /etc/group' is not qualified and no path was specified. Please qualify the command or specify a path.

I fixed it using the full path of binaries in the Exec.
Hope it will help :)
