### PR TITLE
Changes to template output regarding out_copy module.

### DIFF
--- a/spec/defines/fluentd_match_spec.rb
+++ b/spec/defines/fluentd_match_spec.rb
@@ -52,11 +52,11 @@ describe 'fluentd::match' do
         :configfile => 'foo',
         :pattern    => 'baz',
         :type		=> 'copy',
-        :servers    => [{ 'host' => 'kelis', 'port' => '24224'}, { 'host' => 'bossy', 'port' => '24224'}],
         :config     => [
             {
                 'type'              => 'file',
                 'compress'          => 'gzip',
+                'servers'           => [{ 'host' => 'kelis', 'port' => '24224'}, { 'host' => 'bossy', 'port' => '24224'}],
             },
             {
                 'type'              => 'mongo',
@@ -66,7 +66,7 @@ describe 'fluentd::match' do
 		}}
 
 		it "should create matcher with server" do
-			should contain_concat__fragment('match_bar').with_content(/<match baz>.*type.*copy.*<store>.*compress.*gzip.*type.*file.*<\/store>.*<store>.*database.*dummy.*type.*mongo.*<\/store>.*<server>.*host.*kelis.*port.*24224.*<\/server>.*<server>.*host.*bossy.*port.*24224.*<\/server>.*<\/match>/m)
+			should contain_concat__fragment('match_bar').with_content(/<match baz>.*type.*copy.*<store>.*compress.*gzip.*<server>.*host.*kelis.*port.*24224.*<\/server>.*<server>.*host.*bossy.*port.*24224.*<\/server>.*type.*file.*<\/store>.*<store>.*database.*dummy.*type.*mongo.*<\/store>.*<\/match>/m)
 		end
 	end
 

--- a/templates/forest_match.erb
+++ b/templates/forest_match.erb
@@ -1,6 +1,6 @@
 <match <%= @pattern %>>
   type <%= @type %>
-<% @config.each_pair do |key, val| -%>
+<% @config.sort_by{|key,val|key}.each do |key, val| -%>
   <% if val.class == Hash && key == 'template' %> 
     <template>
     <% val.each_pair do |tkey, tval| -%>
@@ -13,7 +13,7 @@
 <% end -%>
 <% @servers.each do |server| -%>
   <server>
-<% @server.each_pair do |key, val| -%>
+<% @server.sort_by{|key,val|key}.each do |key, val| -%>
     <%= key %> <%= val %>
 <% end -%>
   </server>

--- a/templates/match.erb
+++ b/templates/match.erb
@@ -1,24 +1,33 @@
 <match <%= @pattern %>>
     type <%= @type %>
-    <% if @type == 'copy' -%>
-        <% @config.each do |outcopy| -%>
+    <%- if @type == 'copy' -%>
+        <%- @config.each do |outcopy| -%>
         <store>
-            <% outcopy.sort_by{|key,val|key}.each do |key, val| -%>
+            <%- outcopy.sort_by{|key,val|key}.each do |key, val| -%>
+                <%- if key == 'servers' -%>
+                    <%- val.each do |server| -%>
+                        <server>
+                        <%- server.sort_by{|k,v|k}.each do |k,v| -%>
+                            <%= k %> <%= v %>
+                        <%- end -%>
+                    </server>
+                     <%- end -%>
+                <%- else -%>
                 <%= key %> <%= val %>
-            <% end -%>
+                <%- end -%>
+            <%- end -%>
         </store>
-        <% end -%>
-    <% else -%>
-        <% @config.sort_by{|key,val|key}.each do |key, val| -%>
+        <%- end -%>
+    <%- else -%>
+        <%- @config.sort_by{|key,val|key}.each do |key, val| -%>
         <%= key %> <%= val %>
-        <% end -%>
-     <% end -%>
-    <% @servers.each do |server| -%>
+        <%- end -%>
+     <%- end -%>
+    <%- @servers.each do |server| -%>
     <server>
-    <% server.sort_by{|key,val|key}.each do |key, val| -%>
+    <%- server.sort_by{|key,val|key}.each do |key, val| -%>
     <%= key %> <%= val %>
-    <% end -%>
+    <%- end -%>
     </server>
-    <% end -%>
+    <%- end -%>
 </match>
-

--- a/templates/source.erb
+++ b/templates/source.erb
@@ -1,6 +1,6 @@
 <source>
   type <%= @type %>
-<% @config.each_pair do |key, val| -%>
+<% @config.sort_by{|key,val|key}.each do |key, val| -%>
   <%= key %> <%= val %>
 <% end -%>
 <% if @format != false -%>  format <%= @format %><% end %>


### PR DESCRIPTION
Hello again!

While testing I noticed that the inclusion of servers inside an out_copy store definition was not working as expected, with this change you are able to define something like

```
$logger=[{ 'host' => 'logger-sample01', 'port' => '24224'},
              { 'host' => 'logger-example01', 'port' => '24224', 'standby' => ''} ]

    fluentd::match { 'forward_to_logger':
      configfile               => 'sample_tail',
      pattern                  => 'alocal',
      type                     => 'copy',
      config                   => [
      {
        'type'               => 'forward',
        'send_timeout'       => '60s',
        'recover_wait'       => '10s',
        'heartbeat_interval' => '1s',
        'phi_threshold'      => 8,
        'hard_timeout'       => '60s',
        'flush_interval'     => '5s',
        'servers'            => $logger,
      },
      {
            'type'              => 'stdout',
            'output_type'       => 'json',
      }
      ],


    }
```
- Hash loops on all templates are now all sorted to avoid changes with each puppet run.
- Allow for servers to be defined inside a out_copy store
- Format output of config file.
- Modify test to include servers inside an out_copy store

Cheers,

Alejandro
