### PR TITLE
td-agent.conf: Handle both syntax for fluentd v1 and v2

### DIFF
--- a/files/etc/fluentd/td-agent.conf
+++ b/files/etc/fluentd/td-agent.conf
@@ -1,2 +1,0 @@
-# Include config files in the ./config.d directory
-@include config.d/*.conf

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,7 +6,7 @@ class fluentd::config() {
         ensure  => file,
         owner   => 'root',
         group   => 'root',
-        source  => 'puppet:///modules/fluentd/etc/fluentd/td-agent.conf',
+        content => template('fluentd/td-agent.conf.erb'),
         notify  => Class['fluentd::service'],
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,5 +1,6 @@
 # == class fluentd
 class fluentd (
+    $version = '1',
     $package_name = $fluentd::params::package_name,
     $install_repo = $fluentd::params::install_repo,
     $package_ensure = $fluentd::params::package_ensure,

--- a/templates/td-agent.conf.erb
+++ b/templates/td-agent.conf.erb
@@ -1,0 +1,2 @@
+# Include config files in the ./config.d directory
+<% if @version == '2' -%>@<% end %>include config.d/*.conf


### PR DESCRIPTION
Few days ago, I've submitted a PR that was adding an @ in front
of the include as indicated per the source code.
The issue is that syntax is only valid for v2 and is not backward
compatible with v1. This PR fixes that. Sorry for the inconvenience.

PR is https://github.com/mmz-srf/puppet-fluentd/pull/29
