### PR TITLE
Allow for pattern stanzas in source definitions

### DIFF
--- a/manifests/source.pp
+++ b/manifests/source.pp
@@ -6,6 +6,7 @@ define fluentd::source (
     $format       = false,
     $time_format  = false,
     $config       = {},
+    $pattern      = [],
 ) {
 
     concat::fragment { "source_${title}":

--- a/templates/source.erb
+++ b/templates/source.erb
@@ -3,6 +3,13 @@
 <% @config.sort_by{|key,val|key}.each do |key, val| -%>
   <%= key %> <%= val %>
 <% end -%>
+<% @pattern.each do |pat| -%>
+  <pattern>
+<% pat.sort_by{|key,val|key}.each do |key, val| -%>
+    <%= key %> <%= val %>
+<% end -%>
+  </pattern>
+<% end -%>
 <% if @format != false -%>  format <%= @format %><% end %>
 <% if @time_format != false -%>  time_format <%= @time_format %><% end %>
 <% if @tag != false -%>  tag <%= @tag %><% end %>


### PR DESCRIPTION
This patch adds support for pattern blocks. So one can use, e.g., https://github.com/repeatedly/fluent-plugin-multi-format-parser