### PR TITLE
Ability to set ordering when multiple matches share the same file

### DIFF
--- a/manifests/match.pp
+++ b/manifests/match.pp
@@ -5,11 +5,13 @@ define fluentd::match (
     $pattern,
     $config   = {},
     $servers  = [],
+    $order    = undef,
 ) {
 
     concat::fragment { "match_${title}":
         target  => "/etc/td-agent/config.d/${configfile}.conf",
         require => Package["${fluentd::package_name}"],
         content => template('fluentd/match.erb'),
+        order   => $order,
     }
 }


### PR DESCRIPTION
This allows for multiple matches in the same config file to be in a defined order