### PR TITLE
Improve Naming Flexibility

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,7 +2,13 @@
 #
 #
 class fluentd::config() {
-    file { '/etc/td-agent/td-agent.conf' :
+    if $fluentd::product_name == 'fluentd' {
+        $config_file = 'fluent'
+    } else {
+        $config_file = $fluentd::product_name
+    }
+
+    file { "/etc/${fluentd::product_name}/${config_file}.conf" :
         ensure  => file,
         owner   => 'root',
         group   => 'root',
@@ -10,10 +16,10 @@ class fluentd::config() {
         notify  => Class['fluentd::service'],
     }
 
-    file {'/etc/td-agent/config.d':
+    file {"/etc/${fluentd::product_name}/config.d":
         ensure  => 'directory',
-        owner   => 'td-agent',
-        group   => 'td-agent',
+        owner   => "${fluentd::product_name}",
+        group   => "${fluentd::product_name}",
         mode    => '0750',
     }
 }

--- a/manifests/configfile.pp
+++ b/manifests/configfile.pp
@@ -6,8 +6,8 @@ define fluentd::configfile(
 ) {
   $base_name     = "${name}.conf"
   $conf_name     = "${priority}-${base_name}"
-  $conf_path     = "/etc/td-agent/config.d/${conf_name}"
-  $wildcard_path = "/etc/td-agent/config.d/*-${base_name}"
+  $conf_path     = "/etc/${fluentd::product_name}/config.d/${conf_name}"
+  $wildcard_path = "/etc/${fluentd::product_name}/config.d/*-${base_name}"
 
   # clean up in case of a priority change
   exec { "rm ${wildcard_path}":
@@ -25,8 +25,8 @@ define fluentd::configfile(
     file { $conf_path:
       ensure  => $ensure,
       content => $content,
-      owner   => 'td-agent',
-      group   => 'td-agent',
+      owner   => "${fluentd::product_name}",
+      group   => "${fluentd::product_name}",
       mode    => '0644',
       require => Class['fluentd::packages'],
       notify  => Class['fluentd::service'],

--- a/manifests/configfile.pp
+++ b/manifests/configfile.pp
@@ -12,6 +12,7 @@ define fluentd::configfile(
   # clean up in case of a priority change
   exec { "rm ${wildcard_path}":
     onlyif => "test \$(ls ${wildcard_path} | grep -v ${conf_name} | wc -l) -gt 0",
+    path   => ['/usr/bin', '/usr/sbin', '/bin'],
     before => File[$conf_path],
     notify => Class['fluentd::service'],
   }

--- a/manifests/forest_match.pp
+++ b/manifests/forest_match.pp
@@ -8,7 +8,7 @@ define fluentd::forest_match (
 ) {
 
     concat::fragment { "match_${title}":
-        target  => "/etc/td-agent/config.d/${configfile}.conf",
+        target  => "/etc/${fluentd::product_name}/config.d/${configfile}.conf",
         require => Package["${fluentd::package_name}"],
         content => template('fluentd/forest_match.erb'),
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,8 @@ class fluentd (
     $install_repo = $fluentd::params::install_repo,
     $package_ensure = $fluentd::params::package_ensure,
     $service_enable = $fluentd::params::service_enable,
-    $service_ensure = $fluentd::params::service_ensure
+    $service_ensure = $fluentd::params::service_ensure,
+    $service_name = $fluentd::params::service_name
 ) inherits fluentd::params {
     class{'fluentd::packages': }
     class{'fluentd::config': }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,9 @@ class fluentd (
     $service_ensure = $fluentd::params::service_ensure,
     $service_name = $fluentd::params::service_name
 ) inherits fluentd::params {
+    # fluentd vs td-agent
+    $product_name = $service_name
+
     class{'fluentd::packages': }
     class{'fluentd::config': }
     class{'fluentd::service': }

--- a/manifests/install_plugin/file.pp
+++ b/manifests/install_plugin/file.pp
@@ -1,6 +1,6 @@
 # == fluentd::install_plugin::file
 #
-# install a plugin with by copying a file to /etc/td-agent/plugins
+# install a plugin with by copying a file to /etc/${fluentd::product_name}/plugins
 #
 # Parameters:
 #  the name of this ressource reflects the filename of the plugin, which must
@@ -13,10 +13,10 @@ define fluentd::install_plugin::file (
     $plugin_name = $name,
 ) {
     file {
-        "/etc/td-agent/plugin/${plugin_name}":
+        "/etc/${fluentd::product_name}/plugin/${plugin_name}":
             ensure => $ensure,
-            owner  => td-agent,
-            group  => td-agent,
+            owner  => ${fluentd::product_name},
+            group  => ${fluentd::product_name},
             mode   => '0640',
             source => "puppet:///fluentd/plugins/${plugin_name}",
             notify => Service["${::fluentd::service_name}"];

--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -35,10 +35,10 @@ class fluentd::packages (
                 before => Package[$package_name],
                 ensure => $package_ensure
             }
-            exec {'add user td-agent to group adm':
+            exec {"add user ${fluentd::product_name} to group adm":
                 provider => shell,
-                unless => '/bin/grep -q "adm\S*td-agent" /etc/group',
-                command => '/usr/sbin/usermod -aG adm td-agent',
+                unless => "/bin/grep -q \"adm\\S*${fluentd::product_name}\" /etc/group",
+                command => "/usr/sbin/usermod -aG adm ${fluentd::product_name}",
                 subscribe => Package[$package_name],
             }
         }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,7 +4,7 @@ class fluentd::service (
     $service_enable = $fluentd::service_enable,
 ) {
     include fluentd::params
-    service {"${fluentd::params::service_name}":
+    service {"${fluentd::service_name}":
         ensure    => $service_ensure,
         enable    => $service_enable,
         hasstatus => true


### PR DESCRIPTION
This pull request turns several instances of hard-coded names into parameters (with default values), allowing this package to be used with normal fluentd (instead of just with td-agent)